### PR TITLE
add support for string value of prop 'size' and do something little

### DIFF
--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -1,7 +1,7 @@
 <template>
-  <div><div id="avatar" v-bind:style="style">
+  <div id="avatar" v-bind:style="style">
     <span v-if="!this.src">{{ userInitial }}</span>
-  </div></div>
+  </div>
 </template>
 
 <script type="text/babel">

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-el:avatar class="avatar" v-bind:style="style">
-    <span v-if="!this.src">{{ userInitial }}</span>
+    <span v-if="!this.src" style="white-space: nowrap;">{{ userInitial }}</span>
   </div>
 </template>
 
@@ -94,7 +94,8 @@ export default {
         color: this.fontColor,
         display: 'flex',
         justifyContent: 'center',
-        alignItems: 'center'
+        alignItems: 'center',
+        overflow: 'hidden'
       }
 
       const backgroundAndFontStyle = (this.isImage)

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -74,12 +74,11 @@ export default {
 
     style () {
       const style = {
+        flex: 'none',
+        margin: this.margin || 0,
         width: this.size + 'px',
         height: this.size + 'px',
-        borderRadius: this.borderRadius || (this.rounded ? '50%' : 0),
-        margin: this.margin || 0,
-        textAlign: 'center',
-        verticalAlign: 'middle'
+        borderRadius: this.borderRadius || (this.rounded ? '50%' : 0)
       }
 
       const imgBackgroundAndFontStyle = {
@@ -93,7 +92,10 @@ export default {
         font: Math.floor(this.size / 2.5) + 'px/100px Helvetica, Arial, sans-serif',
         fontWeight: 'bold',
         color: this.fontColor,
-        lineHeight: (this.size + Math.floor(this.size / 20)) + 'px'
+        // lineHeight: (this.size + Math.floor(this.size / 20)) + 'px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center'
       }
 
       const backgroundAndFontStyle = (this.isImage)

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="avatar" v-bind:style="style">
+  <div v-el:avatar class="avatar" v-bind:style="style">
     <span v-if="!this.src">{{ userInitial }}</span>
   </div>
 </template>

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -89,10 +89,10 @@ export default {
 
       const initialBackgroundAndFontStyle = {
         backgroundColor: this.background,
-        font: Math.floor(this.size / 2.5) + 'px/100px Helvetica, Arial, sans-serif',
+        fontFamily: 'Helvetica, Arial, sans-serif',
+        fontSize: (this.size / this.userInitial.length) + 'px',
         fontWeight: 'bold',
         color: this.fontColor,
-        // lineHeight: (this.size + Math.floor(this.size / 20)) + 'px',
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center'

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -80,7 +80,7 @@ export default {
     },
 
     isImage () {
-      return this.src !== undefined
+      return this.src !== undefined && this.src !== ''
     },
 
     style () {

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -76,21 +76,19 @@ export default {
       const style = {
         flex: 'none',
         margin: this.margin || 0,
-        width: this.size + 'px',
-        height: this.size + 'px',
+        width: `${this.size}px`,
+        height: `${this.size}px`,
         borderRadius: this.borderRadius || (this.rounded ? '50%' : 0)
       }
 
       const imgBackgroundAndFontStyle = {
-        background: 'url(' + this.src + ') no-repeat',
-        backgroundSize: this.size + 'px ' + this.size + 'px',
-        backgroundOrigin: 'content-box'
+        background: `url(${this.src}) 0% 0% / 100% 100% no-repeat content-box`
       }
 
       const initialBackgroundAndFontStyle = {
         backgroundColor: this.background,
         fontFamily: 'Helvetica, Arial, sans-serif',
-        fontSize: (this.size / this.userInitial.length) + 'px',
+        fontSize: `${this.size / this.userInitial.length}px`,
         fontWeight: 'bold',
         color: this.fontColor,
         display: 'flex',

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="avatar" v-bind:style="style">
+  <div class="avatar" v-bind:style="style">
     <span v-if="!this.src">{{ userInitial }}</span>
   </div>
 </template>

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -22,7 +22,7 @@ export default {
       type: String
     },
     size: {
-      type: Number,
+      type: [String, Number],
       default: 50
     },
     src: {
@@ -59,6 +59,17 @@ export default {
   },
 
   computed: {
+    sizeValue () {
+      return parseFloat(this.size)
+    },
+
+    sizeUnit () {
+      if (typeof this.size === 'number') {
+        return 'px'
+      }
+      return this.size.replace(/[.0-9]/g, '') || 'px'
+    },
+
     background () {
       return this.backgroundColor ||
               this.randomBackgroundColor(this.username.length, this.backgroundColors)
@@ -76,8 +87,8 @@ export default {
       const style = {
         flex: 'none',
         margin: this.margin || 0,
-        width: `${this.size}px`,
-        height: `${this.size}px`,
+        width: `${this.sizeValue}${this.sizeUnit}`,
+        height: `${this.sizeValue}${this.sizeUnit}`,
         borderRadius: this.borderRadius || (this.rounded ? '50%' : 0)
       }
 
@@ -88,7 +99,7 @@ export default {
       const initialBackgroundAndFontStyle = {
         backgroundColor: this.background,
         fontFamily: 'Helvetica, Arial, sans-serif',
-        fontSize: `${this.size / this.userInitial.length}px`,
+        fontSize: `${this.sizeValue / this.userInitial.length}${this.sizeUnit}`,
         fontWeight: 'bold',
         color: this.fontColor,
         display: 'flex',

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -35,6 +35,9 @@ export default {
     borderRadius: {
       type: String
     },
+    margin: {
+      type: String
+    },
     lighten: {
       type: Number,
       default: 80
@@ -74,6 +77,7 @@ export default {
         width: this.size + 'px',
         height: this.size + 'px',
         borderRadius: this.borderRadius || (this.rounded ? '50%' : 0),
+        margin: this.margin || 0,
         textAlign: 'center',
         verticalAlign: 'middle'
       }

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -99,7 +99,6 @@ export default {
       const initialBackgroundAndFontStyle = {
         backgroundColor: this.background,
         fontFamily: 'Helvetica, Arial, sans-serif',
-        fontSize: `${this.sizeValue / this.userInitial.length}${this.sizeUnit}`,
         fontWeight: 'bold',
         color: this.fontColor,
         display: 'flex',
@@ -113,16 +112,36 @@ export default {
 
       Object.assign(style, backgroundAndFontStyle)
 
+      this.$nextTick(function () {
+        this.setFontSize()
+      })
+
       return style
     },
 
     userInitial () {
       const initials = this.initials || this.initial(this.username)
+
+      this.$nextTick(function () {
+        this.setFontSize()
+      })
+
       return initials
     }
   },
 
   methods: {
+    setFontSize () {
+      if (!this.isImage) {
+        const clientWidth = this.$els.avatar.clientWidth
+        if (this.sizeUnit === 'em') {
+          this.$els.avatar.style.width = `${clientWidth}px`
+          this.$els.avatar.style.height = `${clientWidth}px`
+        }
+        this.$els.avatar.style.fontSize = `${clientWidth / this.userInitial.length}px`
+      }
+    },
+
     initial (username) {
       let parts = username.split(/[ -]/)
       let initials = ''

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -32,6 +32,9 @@ export default {
       type: Boolean,
       default: true
     },
+    borderRadius: {
+      type: String
+    },
     lighten: {
       type: Number,
       default: 80
@@ -70,7 +73,7 @@ export default {
       const style = {
         width: this.size + 'px',
         height: this.size + 'px',
-        borderRadius: (this.rounded) ? '50%' : 0,
+        borderRadius: this.borderRadius || (this.rounded ? '50%' : 0),
         textAlign: 'center',
         verticalAlign: 'middle'
       }

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -59,17 +59,6 @@ export default {
   },
 
   computed: {
-    sizeValue () {
-      return parseFloat(this.size)
-    },
-
-    sizeUnit () {
-      if (typeof this.size === 'number') {
-        return 'px'
-      }
-      return this.size.replace(/[.0-9]/g, '') || 'px'
-    },
-
     background () {
       return this.backgroundColor ||
               this.randomBackgroundColor(this.username.length, this.backgroundColors)
@@ -84,11 +73,13 @@ export default {
     },
 
     style () {
+      this.$els.avatar.style.fontSize = 'inherit'
+
       const style = {
         flex: 'none',
         margin: this.margin || 0,
-        width: `${this.sizeValue}${this.sizeUnit}`,
-        height: `${this.sizeValue}${this.sizeUnit}`,
+        width: isNaN(this.size) ? this.size : `${this.size}px`,
+        height: isNaN(this.size) ? this.size : `${this.size}px`,
         borderRadius: this.borderRadius || (this.rounded ? '50%' : 0)
       }
 
@@ -113,7 +104,7 @@ export default {
       Object.assign(style, backgroundAndFontStyle)
 
       this.$nextTick(function () {
-        this.setFontSize()
+        this.adjust()
       })
 
       return style
@@ -123,7 +114,7 @@ export default {
       const initials = this.initials || this.initial(this.username)
 
       this.$nextTick(function () {
-        this.setFontSize()
+        this.adjust()
       })
 
       return initials
@@ -131,15 +122,11 @@ export default {
   },
 
   methods: {
-    setFontSize () {
-      if (!this.isImage) {
-        const clientWidth = this.$els.avatar.clientWidth
-        if (this.sizeUnit === 'em') {
-          this.$els.avatar.style.width = `${clientWidth}px`
-          this.$els.avatar.style.height = `${clientWidth}px`
-        }
-        this.$els.avatar.style.fontSize = `${clientWidth / this.userInitial.length}px`
-      }
+    adjust () {
+      const clientWidth = this.$els.avatar.clientWidth
+      this.$els.avatar.style.width = `${clientWidth}px`
+      this.$els.avatar.style.height = `${clientWidth}px`
+      this.$els.avatar.style.fontSize = `${clientWidth / this.userInitial.length}px`
     },
 
     initial (username) {


### PR DESCRIPTION
@eliep 
Thanks for your greate work and I like this component very much. But when I use it on my project, I found it's not really convenient for me, such as I can't use the 'rem' unit directly. So I start to do something for it, the below are what I do:
1. add support for string value of prop 'size'
2. make sure the words won't overflow the component
3. add 'borderRadius' and 'margin' props
4. other little job

I failed to run the the project on my computer even if I change the version of the babel-runtime module to '^6.0.0', but it can work on my own project.
I just write an ugly but simple [demo](https://devinzhong.github.io/vue-avatar-demo/) to  display what I do, and you can see these features intuitively. 

Although being more bloated, the component is more convenient for me to use. What do you thing of these changes.
