### PR TITLE
Remove unnecessary surrounding div

### DIFF
--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -1,9 +1,7 @@
 <template>
-<div>
   <div class="vue-avatar--wrapper" :style="[style, customStyle]">
     <span v-if="!this.src">{{ userInitial }}</span>
   </div>
-</div>
 </template>
 
 <script>


### PR DESCRIPTION
Surrounding div is unnecessary and makes styling around a bit trickier.

@eliep Thanks for your great component. Very nice. Could you also please release a new official version with all the latest changes? 