### PR TITLE
Inline style update

### DIFF
--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vue-avatar--wrapper" :style="[style, customStyle]">
-    <span v-if="!this.src">{{ userInitial }}</span>
+    <span>{{ !this.src ? userInitial : '&zwnj;' }}</span>
   </div>
 </template>
 
@@ -79,7 +79,9 @@ export default {
       }
 
       const imgBackgroundAndFontStyle = {
-        background: `transparent url('${this.src}') no-repeat scroll 0% 0% / ${this.size}px ${this.size}px content-box border-box`
+        background: `transparent url('${this.src}') no-repeat scroll 0% 0% / ${this.size}px ${this.size}px content-box border-box`,
+        display: this.inline ? 'inline-flex' : 'flex',
+        alignItems: 'center'
       }
 
       const initialBackgroundAndFontStyle = {


### PR DESCRIPTION
With regards to #35.

Added a zero width non joiner (`&zwnj;`) in order to have a placeholder for the span element which influences rendering of text directly behind the element.

```html
<small>
    <Avatar
        username="Corstian Boerman"
        inline size="30"
        class="mr-3"
        src="https://pbs.twimg.com/profile_images/940157009151721472/nVMbmnJf_400x400.jpg" />
        Corstian Boerman
        <br />
        <br />
    <Avatar
        username="Corstian Boerman"
        inline
        size="30"
        class="mr-3" />
            Corstian Boerman
</small>
```

Now parses to:

```html
<small>
    <div class="vue-avatar--wrapper mr-3" style="width: 30px; height: 30px; border-radius: 50%; background: transparent url(&quot;https://pbs.twimg.com/profile_images/940157009151721472/nVMbmnJf_400x400.jpg&quot;) no-repeat scroll 0% 0% / 30px 30px content-box border-box; display: inline-flex; align-items: center;"><span>‌</span></div>
    Corstian Boerman
    <br>
    <br>
    <div class="vue-avatar--wrapper mr-3" style="width: 30px; height: 30px; border-radius: 50%; background-color: rgb(158, 158, 158); font: bold 12px/301px Helvetica, Arial, sans-serif; display: inline-flex; align-items: center; justify-content: center; color: rgb(238, 238, 238);"><span>CB</span></div>
    Corstian Boerman
</small>
```

with the following visual result:

![image](https://user-images.githubusercontent.com/5021647/42994694-0fec18e8-8c0f-11e8-8aa3-02f614365aeb.png)
