### PR TITLE
Add custom parser prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ new Vue({
     <td> true </td>
     <td> Boolean </td>
     <td>True if the avatar must be rounded.</td></tr>
+  <tr><td>:parser</td>
+    <td> N </td>
+    <td> [getInitials()](https://github.com/eliep/vue-avatar/blob/master/src/Avatar.vue#L8-L27) </td>
+    <td> Function </td>
+    <td>Custom parser to manipulate the string (the parser takes
+      2 params: a String and the default parser). It must return a String.</td></tr>
 </tbody>
 </table>
 

--- a/documentation/_getting-started.pug
+++ b/documentation/_getting-started.pug
@@ -170,6 +170,17 @@ a(href='https://github.com/eliep/vue-avatar')
           td  true
           td  Boolean
           td True for a rounded avatar.
+        tr
+          td :parser
+          td  N
+          td
+            | <a href="https://github.com/eliep/vue-avatar/blob/master/src/Avatar.vue#L8-L27"
+            |   rel="noopener noreferrer"
+            |   target="_blank">getInitials()</a>
+          td  Function
+          td
+            | Custom parser to manipulate the string (the parser takes
+            | 2 params: a String and the default parser). It must return a String.
 
     h2 Event
     table.table
@@ -267,6 +278,14 @@ a(href='https://github.com/eliep/vue-avatar')
                 &lt;avatar
                   src="./static/luke-skywalker.png"
                   username="Luke Skywalker"
+        tr
+          td
+            avatar(username='Dr. John Smith', :parser='(name, getInitials) => getInitials(name.slice(3))', :size='100')
+          td
+            pre
+              code.language-html.
+                &lt;avatar username="Dr. John Smith"
+                  :parser="(name, getInitials) => getInitials(name.slice(3))"
                   :size="100"&gt;
                 &lt;/avatar&gt;
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "dist/vue-avatar.min.js",
   "dependencies": {},
   "devDependencies": {
-    "@vue/test-utils": "^1.0.0-beta.20",
+    "@vue/test-utils": "^1.0.0-beta.29",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",

--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -7,6 +7,23 @@
 </template>
 
 <script>
+const getInitials = (username) => {
+  let parts = username.split(/[ -]/)
+  let initials = ''
+
+  for (var i = 0; i < parts.length; i++) {
+    initials += parts[i].charAt(0)
+  }
+
+  if (initials.length > 3 && initials.search(/[A-Z]/) !== -1) {
+    initials = initials.replace(/[a-z]+/g, '')
+  }
+
+  initials = initials.substr(0, 3).toUpperCase()
+
+  return initials
+}
+
 export default {
   name: 'avatar',
   props: {
@@ -42,6 +59,11 @@ export default {
     lighten: {
       type: Number,
       default: 80
+    },
+    parser: {
+      type: Function,
+      default: getInitials,
+      validator: (parser) => typeof parser('John', getInitials) === 'string'
     }
   },
 
@@ -114,7 +136,7 @@ export default {
 
     userInitial () {
       if (!this.isImage) {
-        const initials = this.initials || this.initial(this.username)
+        const initials = this.initials || this.parser(this.username, getInitials)
         return initials
       }
       return ''
@@ -122,22 +144,7 @@ export default {
   },
 
   methods: {
-    initial (username) {
-      let parts = username.split(/[ -]/)
-      let initials = ''
-
-      for (var i = 0; i < parts.length; i++) {
-        initials += parts[i].charAt(0)
-      }
-
-      if (initials.length > 3 && initials.search(/[A-Z]/) !== -1) {
-        initials = initials.replace(/[a-z]+/g, '')
-      }
-
-      initials = initials.substr(0, 3).toUpperCase()
-
-      return initials
-    },
+    initial: getInitials,
 
     onImgError (evt) {
       this.imgError = true

--- a/test/unit/specs/Avatar.spec.js
+++ b/test/unit/specs/Avatar.spec.js
@@ -29,27 +29,54 @@ describe('Avatar.vue', function () {
   })
 
   it('should render initials if no \'src\' is given', function () {
-    var username = 'Hubert-Félix'
+    const username = 'Hubert-Félix'
 
-    var vm = new Vue({
+    const vm = new Vue({
       template: '<div><avatar username="' + username + '"></avatar></div>',
       components: { Avatar }
     }).$mount()
 
-    var initial = vm.$children[0].initial(username)
+    const initial = vm.$children[0].initial(username)
     expect(initial).to.equal('HF')
     expect(vm.$el.querySelector('.vue-avatar--wrapper > span').textContent).to.contain(initial)
   })
 
-  it('should render an image with the correct \'src\' when given', function () {
-    var username = 'Hubert-Félix'
+  it('should use provided parser to render initials if \'parser\' is provided', function () {
+    const username = 'Dr. John Smith'
+    const parser = (name) => name[4]
 
+    const vm = new Vue({
+      template: `<div><avatar username="${username}" :parser="${parser.toString()}"></avatar></div>`,
+      components: { Avatar }
+    }).$mount()
+
+    const initial = parser(username)
+    expect(initial).to.equal('J')
+    expect(vm.$el.querySelector('.vue-avatar--wrapper > span').textContent).to.equal(initial)
+  })
+
+  it('should be able to use default parser in custom parser', function () {
+    const username = 'Dr. John Smith'
+    const parser = (name, getInitials) => getInitials(name.slice(3))
+
+    const vm = new Vue({
+      template: `<div><avatar username="${username}" :parser="${parser.toString()}"></avatar></div>`,
+      components: { Avatar }
+    }).$mount()
+
+    const initial = parser(username, Avatar.methods.initial)
+    expect(initial).to.equal('JS')
+    expect(vm.$el.querySelector('.vue-avatar--wrapper > span').textContent).to.equal(initial)
+  })
+
+  it('should render an image with the correct \'src\' when given', function () {
+    const username = 'Hubert-Félix'
     const wrapper = mount(Avatar, { propsData: {
       username: username,
       src: 'path/to/img'
     } })
 
-    var backgroundImage = wrapper.element.style.backgroundImage
+    const backgroundImage = wrapper.element.style.backgroundImage
     expect(backgroundImage).to.contain('path/to/img')
     expect(wrapper.element.querySelector('.vue-avatar--wrapper > span').textContent).not.to.contain('HF')
   })


### PR DESCRIPTION
This PR sets out to solve issues #44 and #48.

I added a new `parser` prop, which can take a `Function(username, originalParser)`. I figured it'd be nice to expose the original `initial` parser as well, since then people can strip out parts of a string they don't like and then let the original parser handle the rest.

I also added a validator for the prop to make sure that the `parser` function always returns a String.

I added 2 new unit tests. 1 to check if the custom parser works and another to check if the passed in default parser works in the custom parser.

For some reason, the last test (`it should render an image with the correct 'src' when given`) fails for me 🤔 I couldn't come up with a fix for it. Here's the error when it fails:
```
✗ should render an image with the correct 'src' when given
│        undefined is not a constructor (evaluating 'Object.assign({},
│ config,
│              option)')
│        getOption@webpack:///node_modules/@vue/test-utils/dist/vue-te
│st-utils.js:4535:0 <- index.js:17607:25
│        mergeOptions@webpack:///node_modules/@vue/test-utils/dist/vue
│-test-utils.js:4546:0 <- index.js:17618:21
│        mount@webpack:///node_modules/@vue/test-utils/dist/vue-test-u
│tils.js:8642:0 <- index.js:21714:35
│        webpack:///test/unit/specs/Avatar.spec.js:75:26 <- index.js:1
│2864:40
│
│
│PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 9 of 9 (1 FAILED) (0.072 s
│ecs / 0.019 secs)
│TOTAL: 1 FAILED, 8 SUCCESS
│
│
│1) should render an image with the correct 'src' when given
│     Avatar.vue
│     undefined is not a constructor (evaluating 'Object.assign({}, co
│nfig,
│      option)')
│getOption@webpack:///node_modules/@vue/test-utils/dist/vue-test-utils
│.js:4535:0 <- index.js:17607:25
│mergeOptions@webpack:///node_modules/@vue/test-utils/dist/vue-test-ut
│ils.js:4546:0 <- index.js:17618:21
│mount@webpack:///node_modules/@vue/test-utils/dist/vue-test-utils.js:
│8642:0 <- index.js:21714:35
│webpack:///test/unit/specs/Avatar.spec.js:75:26 <- index.js:12864:40
│
```

Edit: closes #44; closes #48 