### PR TITLE
Remove enforced border-radius

### DIFF
--- a/src/Avatar.vue
+++ b/src/Avatar.vue
@@ -106,7 +106,7 @@ export default {
         display: this.inline ? 'inline-flex' : 'flex',
         width: `${this.size}px`,
         height: `${this.size}px`,
-        borderRadius: this.rounded ? '50%' : 0,
+        borderRadius: this.rounded ? '50%' : undefined,
         lineHeight: `${(this.size + Math.floor(this.size / 20))}px`,
         fontWeight: 'bold',
         alignItems: 'center',


### PR DESCRIPTION
Hi,

Thanks for the awesome library.
I think that borderRadius should not be enforced to be 0.
If borderRadius is enforced, user may not able to use class to define style. I'm aware that we can use customStyle to override style properties, but not ideal define customStyle every time.

I myself heavily using tailwind for styling. This fix will enable me to use .rounded-md, .md:rounded-lg, etc. so UI will be more unified across pages.  
https://tailwindcss.com/docs/border-radius